### PR TITLE
fix: chatroom PK 생성전략 ë³략 변경

### DIFF
--- a/llmproject/src/main/java/com/hanieum/llmproject/model/Chatroom.java
+++ b/llmproject/src/main/java/com/hanieum/llmproject/model/Chatroom.java
@@ -13,7 +13,7 @@ import java.util.stream.Collectors;
 @DynamicUpdate
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Chatroom {
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
     @Column(name = "CHATROOM_ID")
     private Long id;
 


### PR DESCRIPTION
## To Reviewers
GeneratedValue 어노테이션을 삭제해서 chatroom Entity의 Pk 생성전략을 db에게 맡기는 것이 아닌
사용자가 직접 입력할 수 있도록 변경하였습니다.

테스트는 따로 해보지 않았고, 중복되는 PK 입력에 대한 예외처리도 해놓지 않았습니다.
긴급하게 PR하느라 나중에 작업 후 추가하겠습니다.