### PR TITLE
Fix: 채팅방 자동생성시 채팅방아이디입력

### DIFF
--- a/llmproject/src/main/java/com/hanieum/llmproject/model/Chatroom.java
+++ b/llmproject/src/main/java/com/hanieum/llmproject/model/Chatroom.java
@@ -13,7 +13,7 @@ import java.util.stream.Collectors;
 @DynamicUpdate
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Chatroom {
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
     @Column(name = "CHATROOM_ID")
     private Long id;
 
@@ -45,8 +45,9 @@ public class Chatroom {
     }
 
     // 채팅저장관련
-    public Chatroom(User user, Category category, String title) {
+    public Chatroom(User user, Long chatroomId, Category category, String title) {
         this.user = user;
+        this.id = chatroomId;
         this.category = category;
         this.title = title;
     }

--- a/llmproject/src/main/java/com/hanieum/llmproject/service/ChatroomService.java
+++ b/llmproject/src/main/java/com/hanieum/llmproject/service/ChatroomService.java
@@ -60,15 +60,15 @@ public class ChatroomService {
         User user = loadUser(userId);
 
         // 채팅방 (사용자, 카테고리, 채팅방아이디 불일치 -> 카테고리항목에 새로운 채팅방생성)
-        Chatroom chatroom = chatroomRepository.findByUserAndCategoryAndId(user,category,chatroomId)
-                .orElseGet(()->createChatRoom(userId, category, title));
+        Chatroom chatroom = chatroomRepository.findByUserAndId(user,chatroomId)
+                .orElseGet(()->createChatRoom(userId,chatroomId, category, title));
         return chatroom.getChatroomId();
     }
 
     // 채팅방 없을시 생성
-    private Chatroom createChatRoom(String userId, Category categoryType, String title) {
+    private Chatroom createChatRoom(String userId, Long chatroomId, Category categoryType, String title) {
         User user = loadUser(userId);
-        Chatroom chatroom = new Chatroom(user, categoryType, title);
+        Chatroom chatroom = new Chatroom(user, chatroomId, categoryType, title);
         System.out.println("채팅방을 생성합니다.");
         chatroomRepository.save(chatroom);
         return chatroom;


### PR DESCRIPTION
채팅방 검색시 유저아이디&채팅방아이디 로만 검색하고, 없으면 채팅방아이디포함하여 채팅방생성
있으면 기존채팅방으로 이동하는형태로 수정했습니다.

근데, 채팅방검색시 카테고리검증은 하지않아서, 채팅방아이디는 일치하고, 카테고리가 일치하지않으면 기존채팅방으로 저장됩니다!

예시) 
123/categoryType=CODE -> 초기생성시 데이터
123/categoryType=PLAN -> 이렇게 카테고리 잘못주입해도 채팅방만 일치하면 그내부로 채팅이 저장됩니다!

카테고리까지 검증하면, [채팅방일치&카테고리 불일치] 일때 기존 채팅방에 카테고리를 덮어쓰게 되어서 이렇게 수정했습니다!