### PR TITLE
FIX: 채팅목록에 chatId같이반환

### DIFF
--- a/llmproject/src/main/java/com/hanieum/llmproject/controller/ChatController.java
+++ b/llmproject/src/main/java/com/hanieum/llmproject/controller/ChatController.java
@@ -53,7 +53,7 @@ public class ChatController {
 	}
 
 	@GetMapping("/chats/{chatroomId}")
-	public Response<List<String>> getChats(@PathVariable("chatroomId") Long chatroomId,
+	public Response<List<Map<String, String>>> getChats(@PathVariable("chatroomId") Long chatroomId,
 										   @RequestParam("categoryType") String categoryType) {
 		return Response.success("채팅을 불러왔습니다.", chatService.getChats(chatroomId, categoryType));
 	}

--- a/llmproject/src/main/java/com/hanieum/llmproject/model/Chat.java
+++ b/llmproject/src/main/java/com/hanieum/llmproject/model/Chat.java
@@ -74,6 +74,8 @@ public class Chat {
 		return this.category.toString();
 	}
 
+	public Long getId() { return this.id;}
+
 	public boolean isUserMessage() {
 		return this.contentType == ContentType.Prompt;
 	}

--- a/llmproject/src/main/java/com/hanieum/llmproject/service/ChatService.java
+++ b/llmproject/src/main/java/com/hanieum/llmproject/service/ChatService.java
@@ -61,7 +61,7 @@ public class ChatService {
 	}
 
 	// 채팅목록 카테고리별로 불러오기
-	public List<String> getChats(Long chatroomId, String categoryType) {
+	public List<Map<String, String>> getChats(Long chatroomId, String categoryType) {
 		var chatroom = chatroomService.findChatroom(chatroomId);
 
 		Category category = loadCategory(categoryType);
@@ -69,8 +69,15 @@ public class ChatService {
 		return chatRepository.findAllByChatroomAndCategory(chatroom, category)
 			.stream()
 			.sorted(Comparator.comparing(Chat::getOutputTime))
-			.map(Chat::getMessage)
+			.map(chat -> {
+				Map<String, String> chatInfo = new HashMap<>();
+				chatInfo.put("chatId", chat.getId().toString());
+				chatInfo.put("message", chat.getMessage());
+				return chatInfo;
+			})
 			.toList();
+
+
 	}
 
 
@@ -112,6 +119,7 @@ public class ChatService {
 		}
 
 		String response = gptService.requestGPT(messages, Category.RETROSPECT);
+		System.out.println("response = " + response);
 		retrospect.setResponse(response);
 
 		retrospectRepository.save(retrospect);


### PR DESCRIPTION
회고체크 기능떄 chatId를 받아와야해서, 채팅목록에서 chatId를 반환해주도록 수정했습니다